### PR TITLE
optimize a piece of code  and repair one bug about compatibility of path separators for window and Linux

### DIFF
--- a/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/inner/ReClassTransform.groovy
+++ b/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/inner/ReClassTransform.groovy
@@ -66,10 +66,8 @@ public class ReClassTransform extends Transform {
         def config = project.extensions.getByName('repluginPluginConfig')
 
         File rootLocation = outputProvider.rootLocation
-        // Windows 系统路径分隔符为 \，split 函数参数为正则表达式，而 \ 在正则表达式中为转义字符，
-        // 所以不能直接使用 （getName()+File.separatorChar），为了方便直接使用 name 分割过滤掉
-        // 第一个路径分割字符
-        def variantDir = rootLocation.absolutePath.split(getName())[1].substring(1)
+        // Compatible with path separators for window and Linux, and fit split param based on 'Pattern.quote'
+        def variantDir = rootLocation.absolutePath.split(getName() + Pattern.quote(File.separator))[1]
 
         println ">>> variantDir: ${variantDir}"
 

--- a/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/inner/ReClassTransform.groovy
+++ b/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/inner/ReClassTransform.groovy
@@ -27,6 +27,9 @@ import javassist.ClassPool
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Project
+
+import java.util.regex.Pattern
+
 /**
  * @author RePlugin Team
  */

--- a/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/manifest/ManifestAPI.groovy
+++ b/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/manifest/ManifestAPI.groovy
@@ -19,6 +19,8 @@ package com.qihoo360.replugin.gradle.plugin.manifest
 
 import org.gradle.api.Project
 
+import java.util.regex.Pattern
+
 /**
  * @author RePlugin Team
  */

--- a/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/manifest/ManifestAPI.groovy
+++ b/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/manifest/ManifestAPI.groovy
@@ -37,7 +37,8 @@ public class ManifestAPI {
      * 获取 AndroidManifest.xml 路径
      */
     def static manifestPath(Project project, String variantDir) {
-        def variantDirArray = variantDir.split("/")
+        // Compatible with path separators for window and Linux, and fit split param based on 'Pattern.quote'
+        def variantDirArray = variantDir.split(Pattern.quote(File.separator))
         String variantName = ""
         variantDirArray.each {
             //首字母大写进行拼接


### PR DESCRIPTION
### Summary
兼容不同系统上的路径分隔符表示，并基于Pattern.quote适配split的正则参数

### Description 
1.优化ReClassTransform类中的路径分割代码片段
2.修复ManifestAPI类中的路径分割bug，在windows下编译，{productFlavors}{buildTypes}均配置了的情况下，因为路径未被正确分割，gradle task名称中含有"\\",会导致无法正确执行gradle task
