### PR TITLE
add lintOptions in library's build.gradle

### DIFF
--- a/replugin-sample/plugin/plugin-demo1/library/build.gradle
+++ b/replugin-sample/plugin/plugin-demo1/library/build.gradle
@@ -19,6 +19,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
### Summary
增加lintOptions配置项，位置：sample-demo1 project中，librarymoudle的build.gradle
### Description 
避免因为hardcode或其他原因导致的lint error
