### PR TITLE
Replugin不重复修改依赖jar

### DIFF
--- a/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/inner/ReClassTransform.groovy
+++ b/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/inner/ReClassTransform.groovy
@@ -176,12 +176,17 @@ public class ReClassTransform extends Transform {
             File jar = new File(it)
             String JarAfterzip = map.get(jar.getParent() + File.separatorChar + jar.getName())
             String dirAfterUnzip = JarAfterzip.replace('.jar', '')
-            // println ">>> 压缩目录 $dirAfterUnzip"
-            
-            Util.zipDir(dirAfterUnzip, JarAfterzip)
 
-            // println ">>> 删除目录 $dirAfterUnzip"
-            FileUtils.deleteDirectory(new File(dirAfterUnzip))
+            if(new File(dirAfterUnzip).exists()){
+                // println ">>> 压缩目录 $dirAfterUnzip"
+
+                Util.zipDir(dirAfterUnzip, JarAfterzip)
+
+                // println ">>> 删除目录 $dirAfterUnzip"
+                FileUtils.deleteDirectory(new File(dirAfterUnzip))
+            }else{
+                println '>>> ignore:no exist '+dirAfterUnzip
+            }
         }
     }
 


### PR DESCRIPTION
每次build都会导致以来jar的内容变化（MD5），减少版本控制没必要的记录。
做法：每次修改jar前，判断jar记录的replugin版本号，如果相同，则不修改。修改完在jar存放要给记录版本号文件。
