### PR TITLE
Set RePluginClassLoader to Thread's ContextClassLoader

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader/utils/PatchClassLoaderUtils.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader/utils/PatchClassLoaderUtils.java
@@ -82,6 +82,10 @@ public class PatchClassLoaderUtils {
             // 将新的ClassLoader写入mPackageInfo.mClassLoader
             ReflectUtils.writeField(oPackageInfo, "mClassLoader", cl);
 
+            // 设置线程上下文中的ClassLoader为RePluginClassLoader
+            // 防止在个别Java库用到了Thread.currentThread().getContextClassLoader()时，“用了原来的PathClassLoader”，或为空指针
+            Thread.currentThread().setContextClassLoader(cl);
+
             if (LOG) {
                 Log.d(TAG, "patch: patch mClassLoader ok");
             }


### PR DESCRIPTION
防止出现调用“Thread.currentThread().getContextClassLoader”出现空指针或不正确的问题（只在Java极个别类库中会用到，绝大多数不会用，而且对框架本身无影响）