### PR TITLE
Resolved the issue of "Overwriting the plug-in, it may not be notified to other processes"

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PmBase.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PmBase.java
@@ -32,7 +32,6 @@ import android.text.TextUtils;
 import com.qihoo360.i.Factory;
 import com.qihoo360.i.IModule;
 import com.qihoo360.i.IPluginManager;
-import com.qihoo360.replugin.utils.ReflectUtils;
 import com.qihoo360.mobilesafe.api.Tasks;
 import com.qihoo360.replugin.IHostBinderFetcher;
 import com.qihoo360.replugin.RePlugin;
@@ -49,6 +48,7 @@ import com.qihoo360.replugin.helper.LogDebug;
 import com.qihoo360.replugin.helper.LogRelease;
 import com.qihoo360.replugin.model.PluginInfo;
 import com.qihoo360.replugin.packages.PluginManagerProxy;
+import com.qihoo360.replugin.utils.ReflectUtils;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
@@ -995,20 +995,6 @@ class PmBase {
 
     final Plugin getPlugin(String plugin) {
         return mPlugins.get(plugin);
-    }
-
-    // 是否为新的，或已经更新过的插件
-    // 注意：若“插件正在运行”时触发更新，则这里应返回false，这样外界将不会发送“新插件”广播
-    final boolean isNewOrUpdatedPlugin(PluginInfo info) {
-        Plugin p = mPlugins.get(info.getName());
-
-        // 满足三个条件的其一就表示为"新插件"，可以做下一步处理
-        // 1. p为空，表示为全新插件
-        // 2. 要安装的版本比当前的要高，且未运行
-        // 3. "待定更新"插件（插件未运行）
-        return p == null ||
-                (p.mInfo.getVersionValue() < info.getVersionValue() && !RePlugin.isPluginRunning(info.getName())) ||
-                (info.getPendingUpdate() != null && !RePlugin.isPluginRunning(info.getName()));
     }
 
     final Plugin loadPackageInfoPlugin(String plugin, PluginCommImpl pm) {

--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/model/PluginInfo.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/model/PluginInfo.java
@@ -34,8 +34,8 @@ import com.qihoo360.replugin.RePlugin;
 import com.qihoo360.replugin.RePluginInternal;
 import com.qihoo360.replugin.helper.JSONHelper;
 import com.qihoo360.replugin.helper.LogDebug;
-
 import com.qihoo360.replugin.utils.FileUtils;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -101,14 +101,18 @@ public class PluginInfo implements Parcelable, Cloneable {
 
     // 若插件需要更新，则会有此值
     private PluginInfo mPendingUpdate;
-    private boolean mIsThisPendingUpdateInfo;
 
     // 若插件需要卸载，则会有此值
     private PluginInfo mPendingDelete;
 
     // 若插件需要同版本覆盖安装更新，则会有此值
     private PluginInfo mPendingCover;
-    private boolean mIsPendingCover;
+    private boolean mIsPendingCover;    // 若当前为“新的PluginInfo”且为“同版本覆盖”，则为了能区分路径，则需要将此字段同步到Json文件中
+
+    // 若当前为“新的PluginInfo”，则其“父Info”是什么？
+    // 通常当前这个Info会包裹在“mPendingUpdate/mPendingDelete/mPendingCover”内
+    // 此信息【不会】做持久化工作。下次重启进程后会消失
+    private PluginInfo mParentInfo;
 
     private PluginInfo(JSONObject jo) {
         initPluginInfo(jo);
@@ -150,7 +154,6 @@ public class PluginInfo implements Parcelable, Cloneable {
      */
     public PluginInfo(PluginInfo pi) {
         this.mJson = JSONHelper.cloneNoThrows(pi.mJson);
-        this.mIsThisPendingUpdateInfo = pi.mIsThisPendingUpdateInfo;
         if (pi.mPendingUpdate != null) {
             this.mPendingUpdate = new PluginInfo(pi.mPendingUpdate);
         }
@@ -160,6 +163,9 @@ public class PluginInfo implements Parcelable, Cloneable {
         this.mIsPendingCover = pi.mIsPendingCover;
         if (pi.mPendingCover != null) {
             this.mPendingCover = new PluginInfo(pi.mPendingCover);
+        }
+        if (pi.mParentInfo != null) {
+            this.mParentInfo = new PluginInfo(pi.mParentInfo);
         }
     }
 
@@ -206,11 +212,6 @@ public class PluginInfo implements Parcelable, Cloneable {
      */
     public static PluginInfo parseFromPackageInfo(PackageInfo pi, String path) {
         ApplicationInfo ai = pi.applicationInfo;
-        if (ai == null) {
-            // 几乎不可能，但为保险起见，返回Null
-            return null;
-        }
-
         String pn = pi.packageName;
         String alias = null;
         int low = 0;
@@ -322,9 +323,9 @@ public class PluginInfo implements Parcelable, Cloneable {
         if (isPnPlugin()) {
             // 为兼容以前逻辑，p-n仍是判断dex是否存在
             return isDexExtracted();
-        } else if (isThisPendingUpdateInfo()) {
+        } else if (getParentInfo() != null) {
             // 若PluginInfo是其它PluginInfo中的PendingUpdate，则返回那个PluginInfo的Used即可
-            return RePlugin.isPluginUsed(getName());
+            return getParentInfo().isUsed();
         } else {
             // 若是纯APK，且不是PendingUpdate，则直接从Json中获取
             return mJson.optBoolean("used");
@@ -625,9 +626,7 @@ public class PluginInfo implements Parcelable, Cloneable {
         setFrameworkVersion(frameVer);
     }
 
-    /**
-     * 获取JSON对象。仅内部使用
-     */
+    // @hide
     public JSONObject getJSON() {
         return mJson;
     }
@@ -669,21 +668,17 @@ public class PluginInfo implements Parcelable, Cloneable {
     }
 
     /**
-     * 此PluginInfo是否是一个位于其它PluginInfo中的PendingUpdate？只在调用RePlugin.install方法才能看到 <p>
-     * 注意：仅框架内部使用
+     * 若此Info为“新PluginInfo”，则这里返回的是“其父Info”的内容。通常和PendingUpdate有关
      *
-     * @return 是否是PendingUpdate的PluginInfo
+     * @return 父PluginInfo
      */
-    public boolean isThisPendingUpdateInfo() {
-        return mIsThisPendingUpdateInfo;
+    public PluginInfo getParentInfo() {
+        return mParentInfo;
     }
 
-    /**
-     * 此PluginInfo是否是一个位于其它PluginInfo中的PendingUpdate？ <p>
-     * 注意：仅框架内部使用
-     */
-    public void setIsThisPendingUpdateInfo(boolean updateInfo) {
-        mIsThisPendingUpdateInfo = updateInfo;
+    // @hide
+    public void setParentInfo(PluginInfo parent) {
+        mParentInfo = parent;
     }
 
     static PluginInfo createByJO(JSONObject jo) {
@@ -769,8 +764,8 @@ public class PluginInfo implements Parcelable, Cloneable {
         }
 
         // 当前是否为PendingUpdate的信息
-        if (mIsThisPendingUpdateInfo) {
-            b.append("[isTPUI] ");
+        if (mParentInfo != null) {
+            b.append("[HAS_PARENT] ");
         }
 
         // 插件类型

--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/packages/PluginManagerServer.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/packages/PluginManagerServer.java
@@ -28,16 +28,16 @@ import com.qihoo360.loader2.CertUtils;
 import com.qihoo360.loader2.MP;
 import com.qihoo360.loader2.PluginNativeLibsHelper;
 import com.qihoo360.mobilesafe.api.Tasks;
-import com.qihoo360.replugin.utils.pkg.PackageFilesUtil;
 import com.qihoo360.replugin.RePlugin;
 import com.qihoo360.replugin.RePluginEventCallbacks;
 import com.qihoo360.replugin.RePluginInternal;
 import com.qihoo360.replugin.base.IPC;
-import com.qihoo360.replugin.utils.FileUtils;
 import com.qihoo360.replugin.helper.LogDebug;
 import com.qihoo360.replugin.helper.LogRelease;
 import com.qihoo360.replugin.model.PluginInfo;
 import com.qihoo360.replugin.model.PluginInfoList;
+import com.qihoo360.replugin.utils.FileUtils;
+import com.qihoo360.replugin.utils.pkg.PackageFilesUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -297,7 +297,6 @@ public class PluginManagerServer {
             }
             if (instPli.getVersion() > curPli.getVersion()) {
                 // 高版本升级
-                instPli.setIsThisPendingUpdateInfo(true);
                 curPli.setPendingUpdate(instPli);
                 curPli.setPendingDelete(null);
                 curPli.setPendingCover(null);
@@ -313,6 +312,9 @@ public class PluginManagerServer {
                     LogDebug.w(TAG, "updateOrLater: Plugin need update same version. clear PendingDelete.");
                 }
             }
+
+            // 设置其Parent为curPli，在PmBase.newPluginFound时会用到
+            instPli.setParentInfo(curPli);
         } else {
             if (LogDebug.LOG) {
                 LogDebug.i(TAG, "updateOrLater: Not running. Update now! pn=" + curPli.getName());

--- a/replugin-sample/host/app/src/main/java/com/qihoo360/replugin/sample/host/MainActivity.java
+++ b/replugin-sample/host/app/src/main/java/com/qihoo360/replugin/sample/host/MainActivity.java
@@ -98,6 +98,18 @@ public class MainActivity extends Activity {
                 }, 1000);
             }
         });
+
+        // 刻意使用Thread的ClassLoader来测试效果
+        testThreadClassLoader();
+    }
+
+    private void testThreadClassLoader() {
+        // 在2.1.7及以前版本，如果直接调用此方法，则拿到的ClassLoader可能是PathClassLoader或者为空。有极个别Java库会用到此方法
+        // 这里务必确保：cl == getClassLoader()，才符合预期
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl != getClassLoader()) {
+            throw new RuntimeException("Thread.current.classLoader != getClassLoader(). cl=" + cl + "; getC=" + getClassLoader());
+        }
     }
 
     private static final int REQUEST_CODE_DEMO1 = 0x011;


### PR DESCRIPTION
解决当插件同版本安装时，由于“没有正确通知到其它进程”，从而其它进程拿到的插件信息是“旧的”的问题。

解决思路：
* 删除isNewOrUpdatePlugin逻辑判断，改为只要安装成功就通知到其它进程
* 允许拿ParentInfo

PS：感谢360手机助手 @kevinfen9 的分析，找到了问题所在。