### PR TITLE
 Support for dynamically assign plugin's custom processes.

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/Loader.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/Loader.java
@@ -533,6 +533,11 @@ class Loader {
         List<String> pluginProcessList = getPluginProcessList();
 
         int hostProcessCount = hostProcessList != null ? hostProcessList.size() : 0;
+
+        if (hostProcessCount <= 0) {
+            return processMap;
+        }
+
         int pluginProcessCount = pluginProcessList != null ? pluginProcessList.size() : 0;
 
         for (int i = 0; i < pluginProcessCount; i++) {
@@ -613,6 +618,11 @@ class Loader {
     }
 
     private void doAdjust(HashMap<String, String> processMap, HashMap<String, ? extends ComponentInfo> infos) {
+
+        if (processMap == null || processMap.isEmpty()) {
+            return;
+        }
+
         for (HashMap.Entry<String, ? extends ComponentInfo> entry : infos.entrySet()) {
             ComponentInfo info = entry.getValue();
             if (info != null) {


### PR DESCRIPTION
插件中，如果存在自定义进程，如`android:process=":process1"`，可以通过配置如下：

        `<meta-data
            android:name="process_map"
            android:value="[
            {'from':'com.qihoo360.replugin.sample.demo1:bg','to':'$p0'}
            ]" />`

来静态的映射到宿主的坑位进程中，如果开发者没有配置该meta-data，则支持自动映射至宿主。

