### PR TITLE
Support "UI process" as a plug-in management process

### DIFF
--- a/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/RePlugin.groovy
+++ b/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/RePlugin.groovy
@@ -228,6 +228,9 @@ class RepluginConfig {
     /** 自定义进程的数量(除 UI 和 Persistent 进程) */
     def countProcess = 3
 
+    /** 是否使用常驻进程？ */
+    def persistentEnable = true
+
     /** 常驻进程名称（也就是上面说的 Persistent 进程，开发者可自定义）*/
     def persistentName = ':GuardService'
 

--- a/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/creator/impl/java/RePluginHostConfigCreator.groovy
+++ b/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/creator/impl/java/RePluginHostConfigCreator.groovy
@@ -65,6 +65,9 @@ public class RePluginHostConfig {
     // 常驻进程名字
     public static String PERSISTENT_NAME = "${config.persistentName}";
 
+    // 是否使用“常驻进程”（见PERSISTENT_NAME）作为插件的管理进程。若为False，则会使用默认进程
+    public static boolean PERSISTENT_ENABLE = ${config.persistentEnable};
+
     // 背景透明的坑的数量（每种 launchMode 不同）
     public static int ACTIVITY_PIT_COUNT_TS_STANDARD = ${config.countTranslucentStandard};
     public static int ACTIVITY_PIT_COUNT_TS_SINGLE_TOP = ${config.countTranslucentSingleTop};

--- a/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/handlemanifest/ComponentsGenerator.groovy
+++ b/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/handlemanifest/ComponentsGenerator.groovy
@@ -71,18 +71,20 @@ class ComponentsGenerator {
 
             /* 需要编译期动态修改进程名的组件*/
 
+            String pluginMgrProcessName = config.persistentEnable ? config.persistentName : applicationID
+
             // 常驻进程Provider
             provider(
                     "${name}":"com.qihoo360.replugin.component.process.ProcessPitProviderPersist",
                     "${authorities}":"${applicationID}.loader.p.main",
                     "${exp}":"false",
-                    "${process}":"${config.persistentName}")
+                    "${process}":"${pluginMgrProcessName}")
 
             provider(
                     "${name}":"com.qihoo360.replugin.component.provider.PluginPitProviderPersist",
                     "${authorities}":"${applicationID}.Plugin.NP.PSP",
                     "${exp}":"false",
-                    "${process}":"${config.persistentName}")
+                    "${process}":"${pluginMgrProcessName}")
 
             // ServiceManager 服务框架
             provider(
@@ -90,12 +92,12 @@ class ComponentsGenerator {
                     "${authorities}":"${applicationID}.svcmanager",
                     "${exp}":"false",
                     "${multiprocess}":"false",
-                    "${process}":"${config.persistentName}")
+                    "${process}":"${pluginMgrProcessName}")
 
             service(
                     "${name}":"com.qihoo360.replugin.component.service.server.PluginPitServiceGuard",
-                    "${process}":"${config.persistentName}")
-            
+                    "${process}":"${pluginMgrProcessName}")
+
             /* 透明坑 */
             config.countTranslucentStandard.times {
                 activity(

--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginProcessMain.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginProcessMain.java
@@ -283,7 +283,7 @@ public class PluginProcessMain {
     /**
      * 非常驻进程调用，获取常驻进程的 IPluginHost
      */
-    static final void installHost() {
+    static final void connectToHostSvc() {
         Context context = PMF.getApplicationContext();
 
         //
@@ -352,6 +352,7 @@ public class PluginProcessMain {
             System.exit(1);
         }
 
+        // 注册该进程信息到“插件管理进程”中
         PMF.sPluginMgr.attach();
     }
 
@@ -369,7 +370,7 @@ public class PluginProcessMain {
                 }
             }
             // 再次唤起常驻进程
-            installHost();
+            connectToHostSvc();
         }
         return sPluginHostRemote;
     }

--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginProviderStub.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginProviderStub.java
@@ -25,13 +25,13 @@ import android.os.IBinder.DeathRecipient;
 import android.os.RemoteException;
 import android.text.TextUtils;
 
-import com.qihoo360.replugin.utils.CloseableUtils;
 import com.qihoo360.loader2.sp.IPref;
 import com.qihoo360.loader2.sp.PrefImpl;
 import com.qihoo360.replugin.base.IPC;
 import com.qihoo360.replugin.component.process.ProcessPitProviderBase;
 import com.qihoo360.replugin.component.process.ProcessPitProviderPersist;
 import com.qihoo360.replugin.helper.LogDebug;
+import com.qihoo360.replugin.utils.CloseableUtils;
 
 import java.util.Arrays;
 
@@ -127,7 +127,7 @@ public class PluginProviderStub {
                     //
                     PMF.sPluginMgr.mLocalCookie = cookie;
                     //
-                    PluginProcessMain.installHost();
+                    PluginProcessMain.connectToHostSvc();
                 }
             }
 

--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/RePluginConfig.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/RePluginConfig.java
@@ -144,30 +144,6 @@ public final class RePluginConfig {
     }
 
     /**
-     * 是否开启"双进程"模式？
-     *
-     * @return 是否开启
-     */
-    public boolean isPersistentEnable() {
-        return persistentEnable;
-    }
-
-    /**
-     * 设置是否允许开启"双进程"模式，开启后会极大的提升插件加载和获取的性能 <p>
-     * TODO 尚不支持单进程模式，在以后会开发
-     *
-     * @param persistentEnable 是否开启
-     * @return RePluginConfig自己。这样可以连环调用set方法
-     */
-    public RePluginConfig setPersistentEnable(boolean persistentEnable) {
-        if (!checkAllowModify()) {
-            return this;
-        }
-        this.persistentEnable = persistentEnable;
-        return this;
-    }
-
-    /**
      * 是否当插件没有指定类时，使用宿主的类？ <p>
      * 有关该开关的具体说明，请参见setUseHostClass方法
      *

--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/base/IPC.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/base/IPC.java
@@ -24,7 +24,6 @@ import android.text.TextUtils;
 
 import com.qihoo360.loader.utils.SysUtils;
 import com.qihoo360.loader2.PluginProcessMain;
-import com.qihoo360.replugin.RePlugin;
 import com.qihoo360.replugin.helper.HostConfigHelper;
 import com.qihoo360.replugin.helper.LogDebug;
 
@@ -58,13 +57,17 @@ public class IPC {
         sPackageName = context.getApplicationInfo().packageName;
 
         // 设置最终的常驻进程名
-        String cppn = HostConfigHelper.PERSISTENT_NAME;
-        if (!TextUtils.isEmpty(cppn)) {
-            if (cppn.startsWith(":")) {
-                sPersistentProcessName = sPackageName + cppn;
-            } else {
-                sPersistentProcessName = cppn;
+        if (HostConfigHelper.PERSISTENT_ENABLE) {
+            String cppn = HostConfigHelper.PERSISTENT_NAME;
+            if (!TextUtils.isEmpty(cppn)) {
+                if (cppn.startsWith(":")) {
+                    sPersistentProcessName = sPackageName + cppn;
+                } else {
+                    sPersistentProcessName = cppn;
+                }
             }
+        } else {
+            sPersistentProcessName = sPackageName;
         }
 
         sIsUIProcess = sCurrentProcess.equals(sPackageName);
@@ -105,11 +108,7 @@ public class IPC {
      * @return 插件处理逻辑所在进程名
      */
     public static String getPluginHostProcessName() {
-        if (isPersistentEnable()) {
-            return getPersistentProcessName();
-        } else {
-            return getCurrentProcessName();
-        }
+        return sPersistentProcessName;
     }
 
     /**
@@ -148,7 +147,7 @@ public class IPC {
      * @return 是否支持？
      */
     public static boolean isPersistentEnable() {
-        return RePlugin.getConfig().isPersistentEnable();
+        return HostConfigHelper.PERSISTENT_ENABLE;
     }
 
     /**

--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/helper/HostConfigHelper.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/replugin/helper/HostConfigHelper.java
@@ -37,6 +37,9 @@ public class HostConfigHelper {
     // 注意:以下配置项必须和 replugin-host-gradle 插件中的配置相同
     //------------------------------------------------------------
 
+    // 是否使用“常驻进程”（见PERSISTENT_NAME）作为插件的管理进程
+    public static boolean PERSISTENT_ENABLE = true;
+
     // 常驻进程名
     public static String PERSISTENT_NAME = ":GuardService";
 
@@ -73,6 +76,12 @@ public class HostConfigHelper {
         try {
             HOST_CONFIG_CLASS = ReflectUtils.getClass(HOST_CONFIG_FILE_PATH + HOST_CONFIG_FILE_NAME);
         } catch (ClassNotFoundException e) {
+            // Ignore, Just use default value
+        }
+
+        try {
+            PERSISTENT_ENABLE = readField("PERSISTENT_ENABLE");
+        } catch (NoSuchFieldException e) {
             // Ignore, Just use default value
         }
 


### PR DESCRIPTION
支持以“UI进程”作为“插件管理”的进程

该模式适用于“App启动时只有一个进程”，或者应用“不需要常驻进程”的情况（当然，开启此模式仍然支持“多进程坑位”的处理）。

此模式也可降低初始化启动RePlugin的时间（无需启动另一进程），然而，一旦UI进程退出，则再次启动的时间会比“常驻进程”模式的要慢一些（因为需要重新初始化、读取插件信息等）。
具体以后会写WiKi来做详述。

适用于此模式的360应用目前有：花椒相机、360借条、360你财富等不需要后台服务的应用
适用于“常驻进程”模式（原）的应用有：360手机卫士、360手机助手、360清理大师等，对后台服务有一定需求应用