### PR TITLE
Resolved issue “Samsung Android 5.1, according to the volume button, crash”

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/Loader.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/Loader.java
@@ -189,6 +189,10 @@ class Loader {
                 mPackageInfo.applicationInfo.sourceDir = mPath;
                 mPackageInfo.applicationInfo.publicSourceDir = mPath;
 
+                if (TextUtils.isEmpty(mPackageInfo.applicationInfo.processName)) {
+                    mPackageInfo.applicationInfo.processName = mPackageInfo.applicationInfo.packageName;
+                }
+
                 // 添加针对SO库的加载
                 // 此属性最终用于ApplicationLoaders.getClassLoader，在创建PathClassLoader时成为其参数
                 // 这样findLibrary可不用覆写，即可直接实现SO的加载


### PR DESCRIPTION
BUG Fix

#### 要解决的问题 
三星手机，Android 5.0， 5.1，打开插件时，按音量键后插件报 NullPointerException

#### 要解决的Issue编号（可多个） Associated issue number (multiple)

详见：https://github.com/Qihoo360/RePlugin/issues/346