### PR TITLE
修复 https://github.com/Qihoo360/RePlugin/issues/344

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginLibraryInternalProxy.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginLibraryInternalProxy.java
@@ -352,7 +352,7 @@ public class PluginLibraryInternalProxy {
             plugin = intent.getComponent().getPackageName();
         }
         // 如果 plugin 是包名，则说明启动的是本插件。
-        if (TextUtils.isEmpty(plugin) || plugin.contains(".")) {
+        if (TextUtils.isEmpty(plugin)) {
             plugin = RePlugin.fetchPluginNameByClassLoader(activity.getClassLoader());
         }
         // 否则是其它插件


### PR DESCRIPTION
修复 https://github.com/Qihoo360/RePlugin/issues/344
宿主无法使用插件包名的方式startActivityForResult调用插件Activity

#### 要解决的问题 Describe the problem to be solved
1.宿主无法使用插件包名的方式startActivityForResult调用插件Activity
2.说起来你可能不信，我真的只删了这一点，宿主就能使用插件包名的方式startActivityForResult调用插件Activity（本地已测试）

#### 要解决的Issue编号（可多个） Associated issue number (multiple)
#344