### PR TITLE
Cancel Override PluginContext's getDatabasePath method

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginContext.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginContext.java
@@ -219,10 +219,14 @@ public class PluginContext extends ContextThemeWrapper {
         return mCacheDir;
     }
 
+/*
+    为了适配 Android 8.1 及后续版本，该方法不再重写，因此，需要各插件之间约定，防止出现重名数据库。
+    by cundong
     @Override
     public File getDatabasePath(String name) {
         return validateFilePath(name, false);
     }
+*/
 
     @Override
     public File getFileStreamPath(String name) {


### PR DESCRIPTION
In order to adapter Android 8.1+, PluginContext's getDatabasePath method is no longer be overloaded, therefore, u need to pay attention when developing plugin, do not use the same database name.

