### PR TITLE
Improve the fileLock's used when releasing the v5-plugin.

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/V5FileInfo.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/V5FileInfo.java
@@ -330,7 +330,7 @@ public class V5FileInfo {
                 LogDebug.d(PLUGIN_TAG, "update v5 plugin: extract ..." + " name=" + mName);
             }
             //
-            File tmpfile = new File(dir, "plugin.tmp");
+            File tmpfile = new File(dir, String.format("%s_plugin.tmp", mName));
             FileUtils.copyInputStreamToFile(dis, tmpfile);
 
             // 检查结果，如果不成功就删除该文件


### PR DESCRIPTION
#### 要解决的问题 

一个极端情况下出现的，因为多进程引发的，插件释放错乱的问题。修改方式比较简单，把整个插件加载过程中的所有元素都进行进程隔离即可。



