### PR TITLE
Load org.apache.http library for P

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/AndroidManifest.xml
+++ b/replugin-host-library/replugin-host-lib/src/main/AndroidManifest.xml
@@ -22,7 +22,10 @@
         <!-- 注意：此文件不要写入与'坑位'配置相关的组件（Activity、Provider），它们由 gradle 插件自动生成） -->
         <!-- 注意：此文件不要写入与'坑位'配置相关的组件（Activity、Provider），它们由 gradle 插件自动生成） -->
         <!-- 注意：此文件不要写入与'坑位'配置相关的组件（Activity、Provider），它们由 gradle 插件自动生成） -->
-
+        
+        <!-- org.apache.http is depracated since Android M. use this for adding the lib to the project for Android P -->
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
+        
         <!-- ======================================================================== -->
         <!-- 开始：插件stub -->
         <!-- Activity坑中的screenSize属性 7.3.0以上才支持 -->


### PR DESCRIPTION

#### 要解决的问题 Describe the problem to be solved
1. org.apache.http is depracated since Android M. use this for adding the lib to the project for Android P 

#### 要解决的Issue编号（可多个） Associated issue number (multiple)
#580