### PR TITLE
解决因splits后，无法正确处理AndroidManifest的问题

### DIFF
--- a/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/RePlugin.groovy
+++ b/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/RePlugin.groovy
@@ -111,6 +111,15 @@ public class Replugin implements Plugin<Project> {
                                     //3.0.0之前，直接使用
                                     manifestFile = file
                                 }
+
+                                if (!manifestFile.exists()) {
+                                    def abi = output.filters.find { it.filterType == OutputFile.ABI }?.identifier
+
+                                    if (abi != null) {
+                                        manifestFile = new File(file, "${abi}/AndroidManifest.xml")
+                                    }
+                                }
+
                                 //检测文件是否存在
                                 if (manifestFile != null && manifestFile.exists()) {
                                     println "${AppConstant.TAG} handle manifest: ${manifestFile}"


### PR DESCRIPTION
#### 要解决的问题 Describe the problem to be solved
1. 当常规处理失败后，检查是否存在abi信息
2. 若存在abi信息，则再进行一次尝试

#### 要解决的Issue编号（可多个） Associated issue number (multiple)
#533 
#581 