### PR TITLE
解决因splits导致AndroidManifest分配坑位失败

### DIFF
--- a/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/RePlugin.groovy
+++ b/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/RePlugin.groovy
@@ -16,6 +16,7 @@
 
 package com.qihoo360.replugin.gradle.host
 
+import com.android.build.OutputFile
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.AppPlugin
 import com.qihoo360.replugin.gradle.host.creator.FileCreators
@@ -111,6 +112,14 @@ public class Replugin implements Plugin<Project> {
                                     //3.0.0之前，直接使用
                                     manifestFile = file
                                 }
+
+                                if (!manifestFile.exists()) {
+                                    def abi = output.filters.find { it.filterType == OutputFile.ABI }?.identifier
+                                    if (abi != null) {
+                                        manifestFile = new File(file, "${abi}/AndroidManifest.xml")
+                                    }
+                                }
+
                                 //检测文件是否存在
                                 if (manifestFile != null && manifestFile.exists()) {
                                     println "${AppConstant.TAG} handle manifest: ${manifestFile}"


### PR DESCRIPTION
#### 要解决的问题 Describe the problem to be solved
1.  由于因splits导致AndroidManifest位置发生变化；
2.  因此当发生此情况时候，再次尝试根据abi判断AndroidManifest位置；

#### 要解决的Issue编号（可多个） Associated issue number (multiple)
#533 #581