### PR TITLE
Update PluginManager.java

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginManager.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PluginManager.java
@@ -86,7 +86,7 @@ public class PluginManager {
     @Deprecated
     static final void init(Context context) {
         // 初始化操作，方便后面执行任务，不必担心Handler为空的情况
-        Tasks.init();
+        // Tasks.init();
         //
         sUid = android.os.Process.myUid();
 


### PR DESCRIPTION
RePlugin 中的 attachBaseContext 方法和 onCreate 方法中，对 Tasks.init(); 进行了重复调用。具体详见：

RePlugin 的 onCreate 方法中调用了 Tasks.init();
RePlugin 的 attachBaseContext 方法中最终在 PluginManager.init(application) 再次调用了 Tasks.init();
经测试，Tasks 在 onCreate 中进行初始化对框架不会产生影响。建议去掉 PluginManager.init 中 Tasks 的初始化业务。

#### 要解决的Issue编号（可多个） Associated issue number (multiple)
#690 