### PR TITLE
#Compat# fix method not found tools.build.gradle.3.2.0

### DIFF
--- a/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/RePlugin.groovy
+++ b/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/RePlugin.groovy
@@ -72,8 +72,7 @@ public class Replugin implements Plugin<Project> {
                 generateHostConfigTask.group = AppConstant.TASKS_GROUP
 
                 //depends on build config task
-                String generateBuildConfigTaskName = variant.getVariantData().getScope().getGenerateBuildConfigTask().name
-                def generateBuildConfigTask = project.tasks.getByName(generateBuildConfigTaskName)
+                def generateBuildConfigTask = variant.getGenerateBuildConfig()
                 if (generateBuildConfigTask) {
                     generateHostConfigTask.dependsOn generateBuildConfigTask
                     generateBuildConfigTask.finalizedBy generateHostConfigTask
@@ -89,8 +88,7 @@ public class Replugin implements Plugin<Project> {
                 generateBuiltinJsonTask.group = AppConstant.TASKS_GROUP
 
                 //depends on mergeAssets Task
-                String mergeAssetsTaskName = variant.getVariantData().getScope().getMergeAssetsTask().name
-                def mergeAssetsTask = project.tasks.getByName(mergeAssetsTaskName)
+                def mergeAssetsTask = variant.getMergeAssets()
                 if (mergeAssetsTask) {
                     generateBuiltinJsonTask.dependsOn mergeAssetsTask
                     mergeAssetsTask.finalizedBy generateBuiltinJsonTask
@@ -151,10 +149,8 @@ public class Replugin implements Plugin<Project> {
         }
         showPluginsTask.group = AppConstant.TASKS_GROUP
 
-        //get mergeAssetsTask name
-        String mergeAssetsTaskName = variant.getVariantData().getScope().getMergeAssetsTask().name
-        //get real gradle task
-        def mergeAssetsTask = project.tasks.getByName(mergeAssetsTaskName)
+        //get mergeAssetsTask name, get real gradle task
+        def mergeAssetsTask = variant.getMergeAssets()
 
         //depend on mergeAssetsTask so that assets have been merged
         if (mergeAssetsTask) {

--- a/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/creator/impl/json/PluginBuiltinJsonCreator.groovy
+++ b/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/creator/impl/json/PluginBuiltinJsonCreator.groovy
@@ -35,11 +35,8 @@ public class PluginBuiltinJsonCreator implements IFileCreator {
     def PluginBuiltinJsonCreator(def project, def variant, def cfg) {
         this.config = cfg
         this.variant = variant
-        //make sure processResources Task execute after mergeAssets Task
-        String mergeAssetsTaskName = variant.getVariantData().getScope().getMergeAssetsTask().name
-        //get real gradle task
-        def mergeAssetsTask = project.tasks.getByName(mergeAssetsTaskName)
-        fileDir = mergeAssetsTask.outputDir
+        //make sure processResources Task execute after mergeAssets Task, get real gradle task
+        fileDir = variant.getMergeAssets()?.outputDir
         fileName = config.builtInJsonFileName
     }
 
@@ -56,7 +53,7 @@ public class PluginBuiltinJsonCreator implements IFileCreator {
     @Override
     String getFileContent() {
         //查找插件文件并抽取信息,如果没有就直接返回null
-        File pluginDirFile = new File(fileDir.getAbsolutePath() + File.separator + config.pluginDir)
+        File pluginDirFile = new File(fileDir?.getAbsolutePath() + File.separator + config.pluginDir)
         if (!pluginDirFile.exists()) {
             println "${AppConstant.TAG} The ${pluginDirFile.absolutePath} does not exist "
             println "${AppConstant.TAG} pluginsInfo=null"


### PR DESCRIPTION
#### 要解决的问题 Describe the problem to be solved

1.  Compile failed 4 `com.android.tools.build:gradle:3.2.0`

```gradle
maven(){ url 'https://dl.google.com/dl/android/maven2/' }
```

```shell
Gradle sync failed: No signature of method: com.android.build.gradle.internal.scope.VariantScopeImpl.getMergeAssetsTask() is applicable for argument types: () values: []
```

#### 要解决的Issue编号（可多个） Associated issue number (multiple)
#640 #646 #661 #724 