### PR TITLE
修改插件ContentProvider update失效问题

### DIFF
--- a/replugin-plugin-library/replugin-plugin-lib/src/main/java/com/qihoo360/replugin/loader/p/PluginProviderClient.java
+++ b/replugin-plugin-library/replugin-plugin-lib/src/main/java/com/qihoo360/replugin/loader/p/PluginProviderClient.java
@@ -184,7 +184,7 @@ public class PluginProviderClient {
         }
 
         try {
-            Object obj = ProxyRePluginProviderClientVar.update.call(null, c, uri);
+            Object obj = ProxyRePluginProviderClientVar.update.call(null, c, uri, values, selection, selectionArgs);
             if (obj != null) {
                 return (Integer) obj;
             }


### PR DESCRIPTION
ContentProvider update 走到框架反射的逻辑时，由于参数对应不上导致调用失败