### PR TITLE
Support Resources#getIdentifier(String, String, String) for android i…

### DIFF
--- a/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/injector/identifier/GetIdentifierExprEditor.groovy
+++ b/replugin-plugin-gradle/src/main/groovy/com/qihoo360/replugin/gradle/plugin/injector/identifier/GetIdentifierExprEditor.groovy
@@ -36,7 +36,7 @@ public class GetIdentifierExprEditor extends ExprEditor {
 
         if (clsName.equalsIgnoreCase('android.content.res.Resources')) {
             if (methodName == 'getIdentifier') {
-                m.replace('{ $3 = \"' + CommonData.appPackage + '\"; ' +
+                m.replace('{ $3 = "android".equals($3) ? $3 : \"' + CommonData.appPackage + '\"; ' +
                         '$_ = $proceed($$);' +
                         ' }')
                 println " GetIdentifierCall => ${filePath} ${methodName}():${m.lineNumber}"


### PR DESCRIPTION
…nternal resources

#### 要解决的问题 Describe the problem to be solved
1.解决通过 getIdentifier 接口不能获取 Android 内部 id 的问题.因为 RePlugin 的 replugin-plugin-gradle 会强制把 package 修改为插件包名


#### 要解决的Issue编号（可多个） Associated issue number (multiple)
# 322