### PR TITLE
支持可变尺寸屏幕

### DIFF
--- a/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/handlemanifest/ComponentsGenerator.groovy
+++ b/replugin-host-gradle/src/main/groovy/com/qihoo360/replugin/gradle/host/handlemanifest/ComponentsGenerator.groovy
@@ -33,7 +33,7 @@ class ComponentsGenerator {
     def static final multiprocess = 'android:multiprocess'
 
     def static final cfg = 'android:configChanges'
-    def static final cfgV = 'keyboard|keyboardHidden|orientation|screenSize'
+    def static final cfgV = 'keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout'
 
     def static final exp = 'android:exported'
     def static final expV = 'false'


### PR DESCRIPTION
通过补充布局属性，支持可变尺寸屏幕。当可变尺寸屏幕（折叠屏）分辨率发生变化时，可确保应用不退出。

#### 要解决的问题 Describe the problem to be solved
1. 可变尺寸屏幕（折叠屏）发生开合时，屏幕尺寸发生变化，此时插件界面退出（插件进程未退出）。通过补充布局属性，结合界面代码中捕获屏幕变化尺寸，并作适当处理（忽略处理），保证屏幕尺寸变化时，插件界面作相应调整，而不是退出插件。


#### 要解决的Issue编号（可多个） Associated issue number (multiple)
#