### PR TITLE
修复插件中 dataDir 返回的是插件路径问题

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/Loader.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/Loader.java
@@ -190,6 +190,12 @@ class Loader {
                 }
                 mPackageInfo.applicationInfo.sourceDir = mPath;
                 mPackageInfo.applicationInfo.publicSourceDir = mPath;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    mPackageInfo.applicationInfo.dataDir = mContext.getDataDir().getAbsolutePath();
+                } else {
+                    String filesDir = mContext.getFilesDir().getAbsolutePath();
+                    mPackageInfo.applicationInfo.dataDir = filesDir.substring(0, filesDir.lastIndexOf('/'));
+                }
 
                 if (TextUtils.isEmpty(mPackageInfo.applicationInfo.processName)) {
                     mPackageInfo.applicationInfo.processName = mPackageInfo.applicationInfo.packageName;


### PR DESCRIPTION
#### 要解决的问题 Describe the problem to be solved
1. 在插件中通过 PluginContext#getApplicationInfo#dataDir() 方法获取的路径是插件的路径，会导致无权限写入，所以修改为宿主的路径。

#### 要解决的Issue编号（可多个） Associated issue number (multiple)
#