### PR TITLE
#FIX:插件设置 taskAffinity 无法启动 #765

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/TaskAffinityStates.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/TaskAffinityStates.java
@@ -96,6 +96,10 @@ class TaskAffinityStates {
                 e.printStackTrace();
             }
 
+            // index在坑位查找失败时会返回-1，导致这里越界
+            // 此处增加修越界检查
+            index = Math.max(0, Math.min(mLaunchModeStates.length - 1, index));
+
             LaunchModeStates states = mLaunchModeStates[index];
             if (states != null) {
                 return states.getStates(ai.launchMode, ai.theme);


### PR DESCRIPTION
#### 要解决的问题 Describe the problem to be solved
1. 设置taskAffinity个数超过repluginConfig中的 countTask时，查找taskAffinity越界问题


#### 要解决的Issue编号（可多个） Associated issue number (multiple)
#765  插件设置多个 taskAffinity后 无法启动 