### PR TITLE
Update PmBase.java

### DIFF
--- a/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PmBase.java
+++ b/replugin-host-library/replugin-host-lib/src/main/java/com/qihoo360/loader2/PmBase.java
@@ -1263,6 +1263,11 @@ class PmBase {
         if (mPlugins.containsKey(info.getName())) {
             mPlugins.remove(info.getName());
         }
+        //移除卸载插件的HashMap中已包名为key的缓存
+        String packageName = info.getPackageName();
+        if (mPlugins.containsKey(packageName)) {
+            mPlugins.remove(packageName);
+        }
 
         // 移除卸载插件表快照
         PluginTable.removeInfo(info);


### PR DESCRIPTION
修复卸载插件时插件信息缓存没有清除的问题。会导致卸载后，新安装的插件无法运行。

#### 要解决的问题 Describe the problem to be solved
1.卸载插件时插件信息缓存没有完全清除(需要清除2个key: 插件名的key、包名的key， 现在只清除了插件名的key)，会导致卸载后，新安装的插件无法运行(无法运行的原因请查看 com.qihoo360.loader2.PmBase#putPluginObject，  当缓存没有完全清空时，会走if 中的逻辑，并且最终不会执行mPlugins.put(xxxx),导致新安装的插件信息无法写入  mPlugins里 )。
